### PR TITLE
Fix 23: consistently forward `loop` argument in `qcd` module

### DIFF
--- a/wilson/util/qcd.py
+++ b/wilson/util/qcd.py
@@ -61,10 +61,10 @@ def m_b(mbmb, scale, f, alphasMZ=0.1185, loop=3):
     if scale == mbmb and f == 5:
         return mbmb  # nothing to do
     _sane(scale, f)
-    alphas_mb = alpha_s(mbmb, 5, alphasMZ=alphasMZ)
+    alphas_mb = alpha_s(mbmb, 5, alphasMZ=alphasMZ, loop=loop)
     crd = rundec.CRunDec()
     if f == 5:
-        alphas_scale = alpha_s(scale, f, alphasMZ=alphasMZ)
+        alphas_scale = alpha_s(scale, f, alphasMZ=alphasMZ, loop=loop)
         return crd.mMS2mMS(mbmb, alphas_mb, alphas_scale, f, loop)
     elif f == 4:
         crd.nfMmu.Mth = 4.8
@@ -80,7 +80,7 @@ def m_b(mbmb, scale, f, alphasMZ=0.1185, loop=3):
         crd.nfMmu.Mth = mc
         crd.nfMmu.muth = mc
         crd.nfMmu.nf = 4
-        alphas_mc = alpha_s(mc, 4, alphasMZ=alphasMZ)
+        alphas_mc = alpha_s(mc, 4, alphasMZ=alphasMZ, loop=loop)
         return crd.mH2mL(mbmc, alphas_mc, mc, crd.nfMmu, scale, loop)
     elif f == 6:
         crd.nfMmu.Mth = 170
@@ -99,9 +99,9 @@ def m_c(mcmc, scale, f, alphasMZ=0.1185, loop=3):
         return mcmc  # nothing to do
     _sane(scale, f)
     crd = rundec.CRunDec()
-    alphas_mc = alpha_s(mcmc, 4, alphasMZ=alphasMZ)
+    alphas_mc = alpha_s(mcmc, 4, alphasMZ=alphasMZ, loop=loop)
     if f == 4:
-        alphas_scale = alpha_s(scale, f, alphasMZ=alphasMZ)
+        alphas_scale = alpha_s(scale, f, alphasMZ=alphasMZ, loop=loop)
         return crd.mMS2mMS(mcmc, alphas_mc, alphas_scale, f, loop)
     elif f == 3:
         crd.nfMmu.Mth = 1.3
@@ -125,9 +125,9 @@ def m_s(ms2, scale, f, alphasMZ=0.1185, loop=3):
         return ms2  # nothing to do
     _sane(scale, f)
     crd = rundec.CRunDec()
-    alphas_2 = alpha_s(2, 3, alphasMZ=alphasMZ)
+    alphas_2 = alpha_s(2, 3, alphasMZ=alphasMZ, loop=loop)
     if f == 3:
-        alphas_scale = alpha_s(scale, f, alphasMZ=alphasMZ)
+        alphas_scale = alpha_s(scale, f, alphasMZ=alphasMZ, loop=loop)
         return crd.mMS2mMS(ms2, alphas_2, alphas_scale, f, loop)
     elif f == 4:
         crd.nfMmu.Mth = 1.3
@@ -143,7 +143,7 @@ def m_s(ms2, scale, f, alphasMZ=0.1185, loop=3):
         crd.nfMmu.Mth = 4.8
         crd.nfMmu.muth = 4.8
         crd.nfMmu.nf = 5
-        alphas_mc = alpha_s(mc, 4, alphasMZ=alphasMZ)
+        alphas_mc = alpha_s(mc, 4, alphasMZ=alphasMZ, loop=loop)
         return crd.mL2mH(msmc, alphas_mc, mc, crd.nfMmu, scale, loop)
     else:
         raise ValueError("Invalid input: f={}, scale={}".format(f, scale))

--- a/wilson/util/qcd.py
+++ b/wilson/util/qcd.py
@@ -18,7 +18,7 @@ MZ = 91.1876
 
 @lru_cache(32)
 def alpha_s(scale, f, alphasMZ=0.1185, loop=3):
-    """3-loop cumputation of alpha_s for f flavours
+    """3-loop computation of alpha_s for f flavours
     with initial condition alpha_s(MZ) = 0.1185"""
     if scale == MZ and f == 5:
         return alphasMZ  # nothing to do

--- a/wilson/util/test_qcd.py
+++ b/wilson/util/test_qcd.py
@@ -4,7 +4,7 @@ from wilson.util.qcd import alpha_s, m_b, m_c, m_s
 # All numbers compared to Mathemetica version of RunDec
 
 delta = 1e-8
-deltam = 1e-5
+deltam = 1e-4
 
 
 class TestMb(unittest.TestCase):
@@ -21,6 +21,18 @@ class TestMb(unittest.TestCase):
         self.assertAlmostEqual(m_b(4.2, 200, 6),
                                2.69632,
                                delta=deltam)
+        self.assertAlmostEqual(m_b(4.163, 50, 5, alphasMZ=0.1181, loop=5),
+                               3.00704,
+                               delta=deltam)
+        self.assertAlmostEqual(m_b(4.163, 2, 4, alphasMZ=0.1181, loop=5),
+                               4.94031,
+                               delta=deltam)
+        self.assertAlmostEqual(m_b(4.163, 1, 3, alphasMZ=0.1181, loop=5),
+                               6.55283,
+                               delta=deltam)
+        self.assertAlmostEqual(m_b(4.163, 200, 6, alphasMZ=0.1181, loop=5),
+                               2.67213,
+                               delta=deltam)
 
 
 class TestMc(unittest.TestCase):
@@ -34,6 +46,15 @@ class TestMc(unittest.TestCase):
         self.assertAlmostEqual(m_c(1.2, 1, 3),
                                1.32125,
                                delta=deltam)
+        self.assertAlmostEqual(m_c(1.279, 50, 5, alphasMZ=0.1181, loop=5),
+                               0.66840,
+                               delta=deltam)
+        self.assertAlmostEqual(m_c(1.279, 2, 4, alphasMZ=0.1181, loop=5),
+                               1.09811,
+                               delta=deltam)
+        self.assertAlmostEqual(m_c(1.279, 1, 3, alphasMZ=0.1181, loop=5),
+                               1.45654,
+                               delta=deltam)
 
 
 class TestMs(unittest.TestCase):
@@ -46,6 +67,15 @@ class TestMs(unittest.TestCase):
                                delta=deltam)
         self.assertAlmostEqual(m_s(0.1, 50, 5),
                                0.0607461,
+                               delta=deltam)
+        self.assertAlmostEqual(m_s(0.095, 1, 3, alphasMZ=0.1181, loop=5),
+                               0.12527,
+                               delta=deltam)
+        self.assertAlmostEqual(m_s(0.095, 2.5, 4, alphasMZ=0.1181, loop=5),
+                               0.08904,
+                               delta=deltam)
+        self.assertAlmostEqual(m_s(0.095, 50, 5, alphasMZ=0.1181, loop=5),
+                               0.05750,
                                delta=deltam)
 
 class TestAlphas(unittest.TestCase):

--- a/wilson/util/test_qcd.py
+++ b/wilson/util/test_qcd.py
@@ -72,6 +72,12 @@ class TestAlphas(unittest.TestCase):
         self.assertAlmostEqual(alpha_s(10, 5),
                                0.17931693160062720703,
                                delta=delta)
+        self.assertAlmostEqual(alpha_s(100, 5, alphasMZ=0.1181, loop=5),
+                               0.1164747252483566,
+                               delta=delta)
+        self.assertAlmostEqual(alpha_s(10, 5, alphasMZ=0.1181, loop=5),
+                               0.17846838859679,
+                               delta=delta)
         # crazy values
         self.assertAlmostEqual(alpha_s(1, 5),
                                0.40957053067188524193,
@@ -84,6 +90,9 @@ class TestAlphas(unittest.TestCase):
         self.assertAlmostEqual(alpha_s(500, 6),
                                0.095517575136454583087,
                                delta=delta)
+        self.assertAlmostEqual(alpha_s(500, 6, alphasMZ=0.1181, loop=5),
+                               0.095272906877950202894,
+                               delta=delta)
         # crazy values
         self.assertAlmostEqual(alpha_s(50, 6),
                                0.12785358110125187370,
@@ -93,6 +102,9 @@ class TestAlphas(unittest.TestCase):
     def test_alphas_4(self):
         self.assertAlmostEqual(alpha_s(3, 4),
                                0.25604161478941490576,
+                               delta=delta)
+        self.assertAlmostEqual(alpha_s(3, 4, alphasMZ=0.1181, loop=5),
+                               0.25391329528950183050,
                                delta=delta)
         # crazy values
         self.assertAlmostEqual(alpha_s(1, 4),
@@ -106,6 +118,9 @@ class TestAlphas(unittest.TestCase):
     def test_alphas_3(self):
         self.assertAlmostEqual(alpha_s(0.9, 3),
                                0.527089,
+                               delta=1e-5)
+        self.assertAlmostEqual(alpha_s(0.9, 3, alphasMZ=0.1181, loop=5),
+                               0.517328,
                                delta=1e-5)
         # crazy values
         self.assertAlmostEqual(alpha_s(1000, 3),


### PR DESCRIPTION
Here is finally the fix for #23.

I have added some new unit tests with non-default values for `alphaMZ` and `loop`. The reference values have been computed using the Mathematica version of RunDec v3.0; the notebook can be found here: [Wilson_qcd_validation.zip](https://github.com/wilson-eft/wilson/files/2837383/Wilson_qcd_validation.zip)

I had to increase the `deltam` threshold from `1e-5` to `1e-4` (GeV), otherwise some tests would not pass. Some decoupling routines seem to introduce errors of order `1e-5`, so there might be a similar difference between the Mathematica and C++/Python versions.

