### PR TITLE
fix decoding error for OS not using UTF-8 as default

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 with open("wilson/_version.py") as f:
     exec(f.read())
 
-with open("README.md") as f:
+with open("README.md", encoding="utf-8") as f:
     LONG_DESCRIPTION = f.read()
 
 setup(


### PR DESCRIPTION
This PR should fix the problem reported in issue #47.