### PR TITLE
update .travis.yml and fix numpy-pandas dependency issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: python
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
-matrix:
-  allow_failures:
-    - python: "3.8"
+  - "3.8"
+  - "3.9"
+#matrix:
+#  allow_failures:
+#    - python: "3.8"
 
 notifications:
   email: false

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ setup(
         ]
     },
     install_requires=[
+        "numpy>=1.16.5",
         "scipy>=1.0",
-        "numpy",
         "pandas",
         "pylha>=0.2",
         "pyyaml",


### PR DESCRIPTION
This PR updates the `.travis.yml` file (removes Python 3.5 and adds Python 3.8 and 3.9) and fixes a dependency issue between pandas and numpy by requiring numpy >= 1.16.5.