### PR TITLE
allow negative m2 and Lambda in `m2Lambda_to_vMh2`

### DIFF
--- a/wilson/run/smeft/smpar.py
+++ b/wilson/run/smeft/smpar.py
@@ -44,8 +44,6 @@ def m2Lambda_to_vMh2(m2, Lambda, C):
     linear order in the Wilson coefficients while the all-order expressions are
     implemented here.
     """
-    if not m2 > 0 or not Lambda > 0:
-        raise ValueError('`m2` and `Lambda` are expected to be positive.')
     Cphi = C['phi'].real
     Ckin = C['phiBox'].real - C['phiD'].real / 4
     if abs(Cphi) < 1e-16:
@@ -55,7 +53,11 @@ def m2Lambda_to_vMh2(m2, Lambda, C):
         if not sqrt_arg >= 0:
             raise ValueError("'Lambda**2 - 12 * Cphi * m2' must be positive.")
         v2 = ( Lambda - sqrt(sqrt_arg) )/( 3 * Cphi )
+    if not v2 > 0:
+        raise ValueError('No solution with positive v2.')
     Mh2 = v2 / ( 1 - 2 * Ckin * v2 ) * ( Lambda - 3 * Cphi * v2 )
+    if not Mh2 > 0:
+        raise ValueError('No solution with positive Mh2.')
     return {'v': sqrt(v2), 'Mh2': Mh2}
 
 def vMh2_to_m2Lambda(v, Mh2, C):

--- a/wilson/run/smeft/tests/test_smpar.py
+++ b/wilson/run/smeft/tests/test_smpar.py
@@ -70,6 +70,27 @@ class TestMh2v(unittest.TestCase):
         self.assertAlmostEqual(d2['v'], v, places=6)
         self.assertAlmostEqual(d2['Mh2'], Mh2, places=6)
 
+    def test_negative_m2Lambda(self):
+        v = 246
+        Mh2 = 125**2
+        C = {k: 0 for k in ['phi', 'phiD']}
+        C['phiBox'] = 1e-5
+        d = smpar.vMh2_to_m2Lambda(v, Mh2, C) # m2 and Lambda negative
+        d2 = smpar.m2Lambda_to_vMh2(d['m2'], d['Lambda'], C)
+        self.assertAlmostEqual(d2['v'], v, places=6)
+        self.assertAlmostEqual(d2['Mh2'], Mh2, places=6)
+        C = {k: 0 for k in ['phiBox', 'phiD']}
+        C['phi'] = -2e-6
+        d = smpar.vMh2_to_m2Lambda(v, Mh2, C) # Lambda negative
+        d2 = smpar.m2Lambda_to_vMh2(d['m2'], d['Lambda'], C)
+        self.assertAlmostEqual(d2['v'], v, places=6)
+        self.assertAlmostEqual(d2['Mh2'], Mh2, places=6)
+        C['phi'] = -3e-6
+        d = smpar.vMh2_to_m2Lambda(v, Mh2, C) # m2 and Lambda negative
+        d2 = smpar.m2Lambda_to_vMh2(d['m2'], d['Lambda'], C)
+        self.assertAlmostEqual(d2['v'], v, places=6)
+        self.assertAlmostEqual(d2['Mh2'], Mh2, places=6)
+
     def test_vreal(self):
         m2 = 7812
         Lambda = 0.258
@@ -78,7 +99,7 @@ class TestMh2v(unittest.TestCase):
         with self.assertRaises(ValueError):
             smpar.m2Lambda_to_vMh2(m2, Lambda, C)
 
-    def test_args_positive(self):
+    def test_vMh2_positive(self):
         v = 246
         Mh2 = 125**2
         m2 = 7812
@@ -89,9 +110,10 @@ class TestMh2v(unittest.TestCase):
         with self.assertRaises(ValueError):
             smpar.vMh2_to_m2Lambda(v, -Mh2, C)
         with self.assertRaises(ValueError):
-            smpar.m2Lambda_to_vMh2(-m2, Lambda, C)
+            smpar.m2Lambda_to_vMh2(-m2, -Lambda, C)
         with self.assertRaises(ValueError):
             smpar.m2Lambda_to_vMh2(m2, -Lambda, C)
+
 
 class TestSMpar(unittest.TestCase):
     def test_smeftpar_small(self):


### PR DESCRIPTION
@jasonaebischerGIT I have noticed that forbidding negative `m2` and `Lambda` in the `m2Lambda_to_vMh2` function was maybe not a good idea. In fact, for certain values of the Wilson coefficients, one or both of these parameters have to be negative in order to get the correct Higgs mass and VEV.

This PR removes the check for positive `m2` and `Lambda` from `m2Lambda_to_vMh2` and instead adds checks for positive `v2` and `Mh2`. It also updates the test cases. In particular, three cases have been added where either only `Lambda` or both `m2` and `Lambda` are negative.