### PR TITLE
Fix two problem discussed in issue #75

### DIFF
--- a/.github/workflows/check+deploy.yaml
+++ b/.github/workflows/check+deploy.yaml
@@ -44,6 +44,11 @@ jobs:
                 python3 ./setup.py bdist_wheel -d ../dist/
                 popd
 
+            - name: Test installing the wheel
+              shell: bash
+              run: |
+                python3 -m pip install dist/wilson-*.whl
+
             - name: Upload build as artifact
               uses: actions/upload-artifact@v1
               with:

--- a/.github/workflows/check+deploy.yaml
+++ b/.github/workflows/check+deploy.yaml
@@ -4,6 +4,9 @@ on:
 
     pull_request:
 
+    release:
+        types: [created]
+
 name: Check & Deploy
 
 jobs:


### PR DESCRIPTION
 - trigger workflow also on created releases
 - test installation of the freshly-built wheel prior to deployment