### PR TITLE
Modernize python to >= 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "rundec>=0.5",
         "voluptuous",
     ],
+    python_requires=">=3.6",
     extras_require={"testing": ["nose"]},
     entry_points={
         "console_scripts": [

--- a/wilson/classes.py
+++ b/wilson/classes.py
@@ -16,7 +16,7 @@ from math import log, e
 from wilson import wcxf
 import voluptuous as vol
 
-class ConfigurableClass(object):
+class ConfigurableClass:
     """Class that provides the functionality to set and get configuration
     options.
 
@@ -228,7 +228,7 @@ class Wilson(ConfigurableClass):
         elif self.wc.eft in ['WET', 'WET-4', 'WET-3']:
             wet = WETrunner(self.wc.translate('JMS', parameters=self.parameters, sectors=translate_sectors), **self._wetrun_opt())
         else:
-            raise ValueError("Input EFT {} unknown or not supported".format(self.wc.eft))
+            raise ValueError(f"Input EFT {self.wc.eft} unknown or not supported")
         if eft == wet.eft:  # just run
             wc_out = wet.run(scale, sectors=sectors).translate(basis, sectors=translate_sectors, parameters=self.parameters)
             self._set_cache(sectors, scale, eft, basis, wc_out)
@@ -254,7 +254,7 @@ class Wilson(ConfigurableClass):
             self._set_cache(sectors, scale, 'WET-3', basis, wc_out)
             return wc_out
         else:
-            raise ValueError("Running from {} to {} not implemented".format(wet.eft, eft))
+            raise ValueError(f"Running from {wet.eft} to {eft} not implemented")
 
     def clear_cache(self):
         self._cache = {}
@@ -278,7 +278,7 @@ class Wilson(ConfigurableClass):
             self._cache[eft][scale][basis][sector] = wc_out
 
 
-class RGsolution(object):
+class RGsolution:
     """Class representing a continuous (interpolated) solution to the
     SMEFT RGEs to be used for plotting."""
 

--- a/wilson/match/test_smeft_loop.py
+++ b/wilson/match/test_smeft_loop.py
@@ -119,4 +119,4 @@ class TestLoopMatch(unittest.TestCase):
                     v_wet = C_WET[kwet][jj]
                 self.assertAlmostEqual(v_wet / v, 1,
                                        delta=1e-5,
-                                       msg="Failed for {} matching into {}".format(k_ii, kwet_jj))
+                                       msg=f"Failed for {k_ii} matching into {kwet_jj}")

--- a/wilson/match/test_smeft_tree_new.py
+++ b/wilson/match/test_smeft_tree_new.py
@@ -41,7 +41,7 @@ class TestSMEFTWETreimpl(unittest.TestCase):
         c_new = wilson.match.smeft_tree.match_all_array(C, p)
         for k in c_old:
             npt.assert_almost_equal(c_old[k], c_new[k], decimal=18,
-                                    err_msg="Failed for {}".format(k))
+                                    err_msg=f"Failed for {k}")
 
     def test_quadratic(self):
         """For WCs entering also quadratically, agreement should be good
@@ -51,4 +51,4 @@ class TestSMEFTWETreimpl(unittest.TestCase):
         c_new = wilson.match.smeft_tree.match_all_array(C, p)
         for k in c_old:
             npt.assert_almost_equal(c_old[k], c_new[k], decimal=10,
-                                    err_msg="Failed for {}".format(k))
+                                    err_msg=f"Failed for {k}")

--- a/wilson/match/test_symmetryfactors.py
+++ b/wilson/match/test_symmetryfactors.py
@@ -108,23 +108,23 @@ class TestMatchingSymmetryFactors(unittest.TestCase):
         for k in C:
             if k in C_symm_keys[41] + C_symm_keys[4] + C_symm_keys[6]:
                 a = np.einsum('klij', C[k]) # C_ijkl = C_klij
-                npt.assert_array_almost_equal(C[k], a, err_msg="Failed for {}".format(k),
+                npt.assert_array_almost_equal(C[k], a, err_msg=f"Failed for {k}",
                                               decimal=20)
             if k in C_symm_keys[5] + C_symm_keys[4] + C_symm_keys[6]:
                 a = np.einsum('jilk', C[k]).conj() # C_ijkl = C_jilk*
-                npt.assert_array_almost_equal(C[k], a, err_msg="Failed for {}".format(k),
+                npt.assert_array_almost_equal(C[k], a, err_msg=f"Failed for {k}",
                                               decimal=20)
             if k in C_symm_keys[4] + C_symm_keys[6]:
                 a = np.einsum('lkji', C[k]).conj() # C_ijkl = C_lkji*
-                npt.assert_array_almost_equal(C[k], a, err_msg="Failed for {}".format(k),
+                npt.assert_array_almost_equal(C[k], a, err_msg=f"Failed for {k}",
                                               decimal=20)
             if k in C_symm_keys[6]:
                 a = np.einsum('ilkj', C[k]) # C_ijkl = C_ilkj
-                npt.assert_array_almost_equal(C[k], a, err_msg="Failed for {}".format(k),
+                npt.assert_array_almost_equal(C[k], a, err_msg=f"Failed for {k}",
                                               decimal=20)
             if k in C_symm_keys[9]:
                 a = -np.einsum('jikl', C[k]) # C_ijkl = -C_jikl
-                npt.assert_array_almost_equal(C[k], a, err_msg="Failed for {}".format(k),
+                npt.assert_array_almost_equal(C[k], a, err_msg=f"Failed for {k}",
                                               decimal=20)
 
     def test_match_symmfac_loop(self):
@@ -136,21 +136,21 @@ class TestMatchingSymmetryFactors(unittest.TestCase):
         for k in C:
             if k in C_symm_keys[41] + C_symm_keys[4] + C_symm_keys[6]:
                 a = np.einsum('klij', C[k]) # C_ijkl = C_klij
-                npt.assert_array_almost_equal(np.array(C[k], complex), np.array(a, complex), err_msg="Failed for {}".format(k),
+                npt.assert_array_almost_equal(np.array(C[k], complex), np.array(a, complex), err_msg=f"Failed for {k}",
                                               decimal=20)
             if k in C_symm_keys[5] + C_symm_keys[4] + C_symm_keys[6]:
                 a = np.einsum('jilk', C[k]).conj() # C_ijkl = C_jilk*
-                npt.assert_array_almost_equal(np.array(C[k], complex), np.array(a, complex), err_msg="Failed for {}".format(k),
+                npt.assert_array_almost_equal(np.array(C[k], complex), np.array(a, complex), err_msg=f"Failed for {k}",
                                               decimal=20)
             if k in C_symm_keys[4] + C_symm_keys[6]:
                 a = np.einsum('lkji', C[k]).conj() # C_ijkl = C_lkji*
-                npt.assert_array_almost_equal(np.array(C[k], complex), np.array(a, complex), err_msg="Failed for {}".format(k),
+                npt.assert_array_almost_equal(np.array(C[k], complex), np.array(a, complex), err_msg=f"Failed for {k}",
                                               decimal=20)
             if k in C_symm_keys[6]:
                 a = np.einsum('ilkj', C[k]) # C_ijkl = C_ilkj
-                npt.assert_array_almost_equal(np.array(C[k], complex), np.array(a, complex), err_msg="Failed for {}".format(k),
+                npt.assert_array_almost_equal(np.array(C[k], complex), np.array(a, complex), err_msg=f"Failed for {k}",
                                               decimal=20)
             if k in C_symm_keys[9]:
                 a = -np.einsum('jikl', C[k]) # C_ijkl = -C_jikl
-                npt.assert_array_almost_equal(np.array(C[k], complex), np.array(a, complex), err_msg="Failed for {}".format(k),
+                npt.assert_array_almost_equal(np.array(C[k], complex), np.array(a, complex), err_msg=f"Failed for {k}",
                                               decimal=20)

--- a/wilson/match/test_wet.py
+++ b/wilson/match/test_wet.py
@@ -27,7 +27,7 @@ class TestWETflavio(unittest.TestCase):
         fkeys_all = set(wcxf.Basis['WET-4', 'flavio'].all_wcs)
         self.assertSetEqual(fkeys_all - fkeys, set(), msg="Missing coefficients")
         for k, v in to_wc.dict.items():
-            self.assertEqual(v, from_wc.dict[k], msg="Failed for {}".format(k))
+            self.assertEqual(v, from_wc.dict[k], msg=f"Failed for {k}")
 
     def test_wet4_wet3(self):
         from_wc = get_random_wc('WET-4', 'flavio')
@@ -37,7 +37,7 @@ class TestWETflavio(unittest.TestCase):
         fkeys_all = set(wcxf.Basis['WET-3', 'flavio'].all_wcs)
         self.assertSetEqual(fkeys_all - fkeys, set(), msg="Missing coefficients")
         for k, v in to_wc.dict.items():
-            self.assertEqual(v, from_wc.dict[k], msg="Failed for {}".format(k))
+            self.assertEqual(v, from_wc.dict[k], msg=f"Failed for {k}")
 
 
 class TestWETBern(unittest.TestCase):
@@ -49,7 +49,7 @@ class TestWETBern(unittest.TestCase):
         fkeys_all = set(wcxf.Basis['WET-4', 'Bern'].all_wcs)
         self.assertSetEqual(fkeys_all - fkeys, set(), msg="Missing coefficients")
         for k, v in to_wc.dict.items():
-            self.assertEqual(v, from_wc.dict[k], msg="Failed for {}".format(k))
+            self.assertEqual(v, from_wc.dict[k], msg=f"Failed for {k}")
 
     def test_wet4_wet3(self):
         from_wc = get_random_wc('WET-4', 'Bern')
@@ -59,7 +59,7 @@ class TestWETBern(unittest.TestCase):
         fkeys_all = set(wcxf.Basis['WET-3', 'Bern'].all_wcs)
         self.assertSetEqual(fkeys_all - fkeys, set(), msg="Missing coefficients")
         for k, v in to_wc.dict.items():
-            self.assertEqual(v, from_wc.dict[k], msg="Failed for {}".format(k))
+            self.assertEqual(v, from_wc.dict[k], msg=f"Failed for {k}")
 
 
 class TestWETJMS(unittest.TestCase):
@@ -71,7 +71,7 @@ class TestWETJMS(unittest.TestCase):
         fkeys_all = set(wcxf.Basis['WET-4', 'JMS'].all_wcs)
         self.assertSetEqual(fkeys_all - fkeys, set(), msg="Missing coefficients")
         for k, v in to_wc.dict.items():
-            self.assertEqual(v, from_wc.dict[k], msg="Failed for {}".format(k))
+            self.assertEqual(v, from_wc.dict[k], msg=f"Failed for {k}")
 
     def test_wet4_wet3(self):
         from_wc = get_random_wc('WET-4', 'JMS')
@@ -81,7 +81,7 @@ class TestWETJMS(unittest.TestCase):
         fkeys_all = set(wcxf.Basis['WET-3', 'JMS'].all_wcs)
         self.assertSetEqual(fkeys_all - fkeys, set(), msg="Missing coefficients")
         for k, v in to_wc.dict.items():
-            self.assertEqual(v, from_wc.dict[k], msg="Failed for {}".format(k))
+            self.assertEqual(v, from_wc.dict[k], msg=f"Failed for {k}")
 
     def test_wet3_wet2(self):
         from_wc = get_random_wc('WET-3', 'JMS')
@@ -91,4 +91,4 @@ class TestWETJMS(unittest.TestCase):
         fkeys_all = set(wcxf.Basis['WET-2', 'JMS'].all_wcs)
         self.assertSetEqual(fkeys_all - fkeys, set(), msg="Missing coefficients")
         for k, v in to_wc.dict.items():
-            self.assertEqual(v, from_wc.dict[k], msg="Failed for {}".format(k))
+            self.assertEqual(v, from_wc.dict[k], msg=f"Failed for {k}")

--- a/wilson/run/smeft/classes.py
+++ b/wilson/run/smeft/classes.py
@@ -11,7 +11,7 @@ from wilson.util import smeftutil
 from wilson import wcxf
 
 
-class SMEFT(object):
+class SMEFT:
     """Class representing a parameter point in the Standard Model Effective
     Field Theory and allowing the evolution of the Wilson Coefficients.
 
@@ -173,7 +173,7 @@ class SMEFT(object):
         elif accuracy == 'leadinglog':
             C_out = self._rgevolve_leadinglog(scale_sm)
         else:
-            raise ValueError("'{}' is not a valid value of 'accuracy' (must be either 'integrate' or 'leadinglog').".format(accuracy))
+            raise ValueError(f"'{accuracy}' is not a valid value of 'accuracy' (must be either 'integrate' or 'leadinglog').")
         return smpar.smpar(C_out)
 
     def _get_sm_scale_in(self, scale_sm=91.1876):
@@ -210,7 +210,7 @@ class SMEFT(object):
         elif accuracy == 'leadinglog':
             C_out = self._rgevolve_leadinglog(scale)
         else:
-            raise ValueError("'{}' is not a valid value of 'accuracy' (must be either 'integrate' or 'leadinglog').".format(accuracy))
+            raise ValueError(f"'{accuracy}' is not a valid value of 'accuracy' (must be either 'integrate' or 'leadinglog').")
         return self._to_wcxf(C_out, scale)
 
     def run_continuous(self, scale):

--- a/wilson/run/smeft/smpar.py
+++ b/wilson/run/smeft/smpar.py
@@ -129,7 +129,7 @@ def smeftpar(scale, C, basis):
         Mu = np.diag([p['m_u'], p['m_c'], p['m_t']])
         Md = K @ np.diag([p['m_d'], p['m_s'], p['m_b']])
     else:
-        raise ValueError("Basis '{}' not supported".format(basis))
+        raise ValueError(f"Basis '{basis}' not supported")
     Me = np.diag([p['m_e'], p['m_mu'], p['m_tau']])
     c['Gd'] = Md / (v / sqrt(2)) + C['dphi'] * (v**2) / 2
     c['Gu'] = Mu / (v / sqrt(2)) + C['uphi'] * (v**2) / 2

--- a/wilson/run/smeft/tests/test_beta.py
+++ b/wilson/run/smeft/tests/test_beta.py
@@ -81,7 +81,7 @@ class TestBeta(unittest.TestCase):
             npt.assert_array_almost_equal(C_out[n]/C_out_ll[n], np.ones((3,3)), decimal=1)
         for n in C4:
             npt.assert_array_almost_equal((C_out[n]/C_out_ll[n]).real, np.ones((3,3,3,3)), decimal=1,
-                err_msg="failed for {}".format(n))
+                err_msg=f"failed for {n}")
 
     def test_sm(self):
         beta_np = beta.beta(C,  HIGHSCALE)

--- a/wilson/run/smeft/tests/test_classes.py
+++ b/wilson/run/smeft/tests/test_classes.py
@@ -28,7 +28,7 @@ class TestSMEFT(unittest.TestCase):
         for k, v in C_in_sm_2.items():
             if k not in SM_keys:
                 npt.assert_array_equal(v, C_in_sm[k],
-                                       err_msg="Failed for {}".format(k))
+                                       err_msg=f"Failed for {k}")
     #
     # def test_rotation(self):
     #     wcout = pkgutil.get_data('wilson', 'run/smeft/tests/data/Output_SMEFTrunner.dat').decode('utf-8')

--- a/wilson/run/smeft/tests/test_smpar.py
+++ b/wilson/run/smeft/tests/test_smpar.py
@@ -158,7 +158,7 @@ class TestSMpar(unittest.TestCase):
         for k in smpar.p:
             if k not in ['m_Z', 'delta']:
                 self.assertAlmostEqual(smpar.p[k], Cback[k],
-                                       msg="Failed for {}".format(k))
+                                       msg=f"Failed for {k}")
 
 
     def test_smpar_roundtrip(self):
@@ -173,15 +173,15 @@ class TestSMpar(unittest.TestCase):
         for k in smpar.p:
             if k in ['m_Z']:
                 self.assertAlmostEqual(smpar.p[k]/Cback[k], 1,
-                                       msg="Failed for {}".format(k),
+                                       msg=f"Failed for {k}",
                                        delta=0.05)
             elif k in ['delta']:
                 self.assertAlmostEqual(smpar.p[k]/Cback[k], 1,
-                                       msg="Failed for {}".format(k),
+                                       msg=f"Failed for {k}",
                                        delta=1e-3)
             else:
                 self.assertAlmostEqual(smpar.p[k]/Cback[k], 1,
-                                       msg="Failed for {}".format(k),
+                                       msg=f"Failed for {k}",
                                        delta=1e-5)
 
 class TestGetSMpar(unittest.TestCase):
@@ -193,7 +193,7 @@ class TestGetSMpar(unittest.TestCase):
         for k in p_out:
             self.assertAlmostEqual(p_out[k] / smpar.p[k], 1,
                                    delta=0.05,
-                                   msg="Failed for {}".format(k))
+                                   msg=f"Failed for {k}")
 
     def test_wcxf_smpar_incomplete(self):
         wc = wcxf.WC('SMEFT', 'Warsaw', 160, {'qd1_1111': {'Im': 1e-6}})
@@ -207,4 +207,4 @@ class TestGetSMpar(unittest.TestCase):
         p_def = smpar.p
         for k, v in p_out.items():
             self.assertAlmostEqual(v / p_def[k], 1, places=1,
-                                   msg="Failed for {}".format(k))
+                                   msg=f"Failed for {k}")

--- a/wilson/run/wet/classes.py
+++ b/wilson/run/wet/classes.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 import numpy as np
 
 
-class WETrunner(object):
+class WETrunner:
     """Class representing a point in Wilson coefficient space.
 
     Methods:

--- a/wilson/run/wet/rge.py
+++ b/wilson/run/wet/rge.py
@@ -28,7 +28,7 @@ def get_permissible_wcs(classname, f):
         sector = 'dF=0'
     else:
         sector = classname
-    perm_keys = wcxf.Basis['WET-{}'.format(f), 'JMS'].sectors[sector].keys()
+    perm_keys = wcxf.Basis[f'WET-{f}', 'JMS'].sectors[sector].keys()
     all_keys = coeffs[sector]
     return [i for i, c in enumerate(all_keys) if c in perm_keys]
 

--- a/wilson/run/wet/test_wetrunner.py
+++ b/wilson/run/wet/test_wetrunner.py
@@ -28,7 +28,7 @@ class TestDef(unittest.TestCase):
             allkeys = wcxf.Basis['WET', 'JMS'].sectors[sname].keys()
             # for c in clist:
                 # self.assertIn(c, allkeys, msg="{} not found in {}".format(c, sname))
-            self.assertSetEqual(set(clist), set(allkeys), msg="Failed for {}".format(sname))
+            self.assertSetEqual(set(clist), set(allkeys), msg=f"Failed for {sname}")
 
 
 class TestClass(unittest.TestCase):
@@ -59,7 +59,7 @@ class TestClass(unittest.TestCase):
         # (not vice versa as RGE can generate them from zero)
         for k in self.wet.C_in:
             self.assertTrue(k in C_out,
-                            msg='{} missing in output'.format(k))
+                            msg=f'{k} missing in output')
 
 
 class TestEvolutionMatrices(unittest.TestCase):
@@ -69,7 +69,7 @@ class TestEvolutionMatrices(unittest.TestCase):
         for c in ['I', 'II', 'III', 'IV', 'IVe', 'sb', 'db', 'sd', 'mue', 'cu', 'Vb']:
             npt.assert_array_almost_equal(rge.getUs(c, 0.123, *args),
                                           np.linalg.inv(rge.getUs(c, 1/0.123, *args),),
-                                          err_msg="Failed for {}".format(c))
+                                          err_msg=f"Failed for {c}")
 
 
 class TestClassWET4(unittest.TestCase):
@@ -89,7 +89,7 @@ class TestClassWET4(unittest.TestCase):
         # (not vice versa as RGE can generate them from zero)
         for k in self.wet.C_in:
             self.assertTrue(k in C_out,
-                            msg='{} missing in output'.format(k))
+                            msg=f'{k} missing in output')
 
 class TestOrder(unittest.TestCase):
     @classmethod
@@ -109,18 +109,18 @@ class TestOrder(unittest.TestCase):
         wc_hi = self.wet_11.run(160, ('sbsb',))
         wc_lo = self.wet_00.run(4, ('sbsb',))
         for k, v in wc_lo.dict.items():
-            self.assertAlmostEqual(v, wc_hi[k], msg="Failed for {}".format(k))
+            self.assertAlmostEqual(v, wc_hi[k], msg=f"Failed for {k}")
 
     def test_10(self):
         # running without QED = running with alpha_e = 0
         wc_10 = self.wet_10.run(4, ('sbsb',))
         wc_11 = self.wet_11_ae0.run(4, ('sbsb',))
         for k, v in wc_10.dict.items():
-            self.assertAlmostEqual(v, wc_11[k], msg="Failed for {}".format(k))
+            self.assertAlmostEqual(v, wc_11[k], msg=f"Failed for {k}")
 
     def test_01(self):
         # running without QED = running with alpha_e = 0
         wc_01 = self.wet_01.run(4, ('sbsb',))
         wc_11 = self.wet_11_as0.run(4, ('sbsb',))
         for k, v in wc_01.dict.items():
-            self.assertAlmostEqual(v, wc_11[k], msg="Failed for {}".format(k))
+            self.assertAlmostEqual(v, wc_11[k], msg=f"Failed for {k}")

--- a/wilson/translate/test_smeft.py
+++ b/wilson/translate/test_smeft.py
@@ -32,7 +32,7 @@ class TestWarsawMass(unittest.TestCase):
             for k, v in wc_Warsaw_random.dict.items():
                 if k.split('_')[0] not in ['uphi', 'uG', 'uW', 'uB', 'llphiphi']:
                     self.assertEqual(wcW.dict[k], v,
-                                     msg="Not equal for {}".format(k))
+                                     msg=f"Not equal for {k}")
             for i in range(3):
                 for j in range(3):
                     if i > j:
@@ -50,7 +50,7 @@ class TestWarsawUp(unittest.TestCase):
             wc_roundtrip = wcW.translate('Warsaw')
             for k, v in wcWdown.dict.items():
                 self.assertAlmostEqual(v, wc_roundtrip.dict[k], places=12,
-                                       msg="Failed for {}".format(k))
+                                       msg=f"Failed for {k}")
 
 
 class TestIO(unittest.TestCase):
@@ -61,4 +61,4 @@ class TestIO(unittest.TestCase):
         C_wcxf = wilson.util.smeftutil.arrays2wcxf(C_arr)
         for k, v in wc.dict.items():
             self.assertEqual(v, C_wcxf[k],
-                             msg="Failed for {}".format(k))
+                             msg=f"Failed for {k}")

--- a/wilson/translate/test_smeft_higgs.py
+++ b/wilson/translate/test_smeft_higgs.py
@@ -35,5 +35,5 @@ class TestHiggs(unittest.TestCase):
             wc_roundtrip = wc_translated.translate("Warsaw up")
             for k, v in wc.dict.items():
                 self.assertAlmostEqual(
-                    v, wc_roundtrip.dict[k], places=20, msg="Failed for {}".format(k)
+                    v, wc_roundtrip.dict[k], places=20, msg=f"Failed for {k}"
                 )

--- a/wilson/translate/test_wet.py
+++ b/wilson/translate/test_wet.py
@@ -27,7 +27,7 @@ def _test_missing(self, wc, from_basis, ignore_sec=[], ignore_coeffs=[]):
             continue
         to_keys_all = set(coeffs.keys())
         self.assertSetEqual(to_keys_all - to_keys - set(ignore_coeffs), set(),
-                            msg="Missing coefficients in sector {}".format(sec))
+                            msg=f"Missing coefficients in sector {sec}")
 
 
 class TestJMS2Flavio(unittest.TestCase):
@@ -42,12 +42,12 @@ class TestJMS2Flavio(unittest.TestCase):
 
     def test_nan(self):
         for k, v in self.flavio_wc.dict.items():
-            self.assertFalse(np.isnan(v), msg="{} is NaN".format(k))
+            self.assertFalse(np.isnan(v), msg=f"{k} is NaN")
 
     def test_missing(self):
         fkeys = set(self.flavio_wc.values.keys())
-        fkeys_all = set([k for s in wcxf.Basis['WET', 'flavio'].sectors.values()
-                         for k in s])
+        fkeys_all = {k for s in wcxf.Basis['WET', 'flavio'].sectors.values()
+                         for k in s}
         self.assertSetEqual(fkeys_all - fkeys, set(), msg="Missing coefficients")
 
     def test_incomplete_input(self):
@@ -80,12 +80,12 @@ class TestJMS2FlavioWET3(unittest.TestCase):
 
     def test_nan(self):
         for k, v in self.flavio_wc.dict.items():
-            self.assertFalse(np.isnan(v), msg="{} is NaN".format(k))
+            self.assertFalse(np.isnan(v), msg=f"{k} is NaN")
 
     def test_missing(self):
         fkeys = set(self.flavio_wc.values.keys())
-        fkeys_all = set([k for s in wcxf.Basis['WET-3', 'flavio'].sectors.values()
-                         for k in s])
+        fkeys_all = {k for s in wcxf.Basis['WET-3', 'flavio'].sectors.values()
+                         for k in s}
         self.assertSetEqual(fkeys_all - fkeys, set(), msg="Missing coefficients")
 
     def test_incomplete_input(self):
@@ -109,13 +109,13 @@ class TestJMS2Bern(unittest.TestCase):
 
     def test_nan(self):
         for k, v in self.bern_wc.dict.items():
-            self.assertFalse(np.isnan(v), msg="{} is NaN".format(k))
+            self.assertFalse(np.isnan(v), msg=f"{k} is NaN")
 
     def test_missing(self):
         bkeys = set(self.bern_wc.values.keys())
-        bkeys_all = set([k for sname, s in wcxf.Basis['WET', 'Bern'].sectors.items()
+        bkeys_all = {k for sname, s in wcxf.Basis['WET', 'Bern'].sectors.items()
                          for k in s
-                         if sname not in ['dF=0', ]])
+                         if sname not in ['dF=0', ]}
         self.assertSetEqual(bkeys_all - bkeys, set(), msg="Missing coefficients")
 
 
@@ -131,7 +131,7 @@ class TestBern2JMS(unittest.TestCase):
 
     def test_nan(self):
         for k, v in self.to_wc.dict.items():
-            self.assertFalse(np.isnan(v), msg="{} is NaN".format(k))
+            self.assertFalse(np.isnan(v), msg=f"{k} is NaN")
 
     def test_missing(self):
         _test_missing(self, self.to_wc, 'Bern',
@@ -143,7 +143,7 @@ class TestBern2JMS(unittest.TestCase):
         for k, v in round_wc.dict.items():
             self.assertAlmostEqual(v, self.from_wc.dict[k],
                                    delta=1e-12,
-                                   msg="Failed for {}".format(k))
+                                   msg=f"Failed for {k}")
 
 
 class TestFlavio2JMS(unittest.TestCase):
@@ -158,16 +158,16 @@ class TestFlavio2JMS(unittest.TestCase):
 
     def test_nan(self):
         for k, v in self.to_wc.dict.items():
-            self.assertFalse(np.isnan(v), msg="{} is NaN".format(k))
+            self.assertFalse(np.isnan(v), msg=f"{k} is NaN")
 
     def test_missing(self):
         # ignore tensor coeffs
-        ignore = ['TedRR_{}{}{}{}'.format(i, j, k, l)
+        ignore = [f'TedRR_{i}{j}{k}{l}'
                   for i in '123'
                   for j in '123'
                   for k in '123'
                   for l in '123'
-                  ] + ['TeuRR_{}{}{}{}'.format(i, j, k, l)
+                  ] + [f'TeuRR_{i}{j}{k}{l}'
                             for i in '123'
                             for j in '123'
                             for k in '123'
@@ -181,7 +181,7 @@ class TestFlavio2JMS(unittest.TestCase):
         for k, v in round_wc.dict.items():
             self.assertAlmostEqual(v, self.from_wc.dict[k],
                                    delta=1e-12,
-                                   msg="Failed for {}".format(k))
+                                   msg=f"Failed for {k}")
 
 
 class TestJMS2BernWET3(unittest.TestCase):
@@ -196,13 +196,13 @@ class TestJMS2BernWET3(unittest.TestCase):
 
     def test_nan(self):
         for k, v in self.bern_wc.dict.items():
-            self.assertFalse(np.isnan(v), msg="{} is NaN".format(k))
+            self.assertFalse(np.isnan(v), msg=f"{k} is NaN")
 
     def test_missing(self):
         bkeys = set(self.bern_wc.values.keys())
-        bkeys_all = set([k for s in wcxf.Basis['WET-3', 'Bern'].sectors.values()
+        bkeys_all = {k for s in wcxf.Basis['WET-3', 'Bern'].sectors.values()
                          for k in s
-                         if 'b' in k]) # for the time being, only look at b operators
+                         if 'b' in k} # for the time being, only look at b operators
         self.assertSetEqual(bkeys_all - bkeys, set(), msg="Missing coefficients")
 
 
@@ -218,12 +218,12 @@ class TestJMS2EOS(unittest.TestCase):
 
     def test_nan(self):
         for k, v in self.eos_wc.dict.items():
-            self.assertFalse(np.isnan(v), msg="{} is NaN".format(k))
+            self.assertFalse(np.isnan(v), msg=f"{k} is NaN")
 
     def test_missing(self):
         fkeys = set(self.eos_wc.values.keys())
-        fkeys_all = set([k for s in wcxf.Basis['WET', 'EOS'].sectors.values()
-                         for k in s])
+        fkeys_all = {k for s in wcxf.Basis['WET', 'EOS'].sectors.values()
+                         for k in s}
         self.assertSetEqual(fkeys_all - fkeys, set(), msg="Missing coefficients")
 
 class TestJMS2FormFlavor(unittest.TestCase):
@@ -238,12 +238,12 @@ class TestJMS2FormFlavor(unittest.TestCase):
 
     def test_nan(self):
         for k, v in self.formflavor_wc.dict.items():
-            self.assertFalse(np.isnan(v), msg="{} is NaN".format(k))
+            self.assertFalse(np.isnan(v), msg=f"{k} is NaN")
 
     def test_missing(self):
         fkeys = set(self.formflavor_wc.values.keys())
-        fkeys_all = set([k for s in wcxf.Basis['WET', 'formflavor'].sectors.values()
-                         for k in s])
+        fkeys_all = {k for s in wcxf.Basis['WET', 'formflavor'].sectors.values()
+                         for k in s}
         self.assertSetEqual(fkeys_all - fkeys, set(), msg="Missing coefficients")
 
 
@@ -258,7 +258,7 @@ class TestFlavorKit2JMS(unittest.TestCase):
 
     def test_nan(self):
         for k, v in self.jms_wc.dict.items():
-            self.assertFalse(np.isnan(v), msg="{} is NaN".format(k))
+            self.assertFalse(np.isnan(v), msg=f"{k} is NaN")
 
     def count_nonzero(self):
         self.assertEqual(len(self.jms_wc.dict), len(self.fk_wc.dict))
@@ -284,15 +284,15 @@ class TestJMS2FlavorKit(unittest.TestCase):
 
     def test_nan(self):
         for k, v in self.fk_wc.dict.items():
-            self.assertFalse(np.isnan(v), msg="{} is NaN".format(k))
+            self.assertFalse(np.isnan(v), msg=f"{k} is NaN")
 
     def count_nonzero(self):
         self.assertEqual(len(self.fk_wc.dict), len(self.fk_wc.dict))
 
     def test_missing(self):
         fkeys = set(self.fk_wc.values.keys())
-        fkeys_all = set([k for s in wcxf.Basis['WET', 'FlavorKit'].sectors.values()
-                         for k in s])
+        fkeys_all = {k for s in wcxf.Basis['WET', 'FlavorKit'].sectors.values()
+                         for k in s}
         self.assertSetEqual(fkeys_all - fkeys, set(), msg="Missing coefficients")
 
     def test_incomplete_input(self):
@@ -316,7 +316,7 @@ class TestBern2flavio(unittest.TestCase):
 
     def test_nan(self):
         for k, v in self.to_wc.dict.items():
-            self.assertFalse(np.isnan(v), msg="{} is NaN".format(k))
+            self.assertFalse(np.isnan(v), msg=f"{k} is NaN")
 
     def count_nonzero(self):
         self.assertEqual(len(self.to_wc.dict), len(self.to_wc.dict))
@@ -327,7 +327,7 @@ class TestBern2flavio(unittest.TestCase):
             if k[0] != '7':  # to avoid problem with flavio tensors missing
                 self.assertAlmostEqual(v, self.from_wc.dict[k],
                                        delta=1e-12,
-                                       msg="Failed for {}".format(k))
+                                       msg=f"Failed for {k}")
 
     def test_jms(self):
         jms_wc = get_random_wc('WET', 'JMS')
@@ -337,7 +337,7 @@ class TestBern2flavio(unittest.TestCase):
             if k in jms_indirect.dict:
                 self.assertAlmostEqual(v, jms_indirect.dict[k],
                                        delta=1e-5,
-                                       msg="Failed for {}".format(k))
+                                       msg=f"Failed for {k}")
 
     def test_incomplete_input(self):
         # generate and input WC instance with just 1 non-zero coeff.
@@ -352,9 +352,9 @@ class TestBern2flavio(unittest.TestCase):
 
     def test_missing(self):
         fkeys = set(self.to_wc.values.keys())
-        fkeys_all = set([k for sname, s in wcxf.Basis['WET', 'flavio'].sectors.items()
+        fkeys_all = {k for sname, s in wcxf.Basis['WET', 'flavio'].sectors.items()
                          for k in s
-                         if sname not in ['mue', 'mutau', 'taue', 'nunumue', 'nunumutau', 'nunutaue', 'dF=0', 'ffnunu', 'etauemu', 'muemutau', 'cu']])  # LFV, dF=0, dC=1 not in Bern
+                         if sname not in ['mue', 'mutau', 'taue', 'nunumue', 'nunumutau', 'nunutaue', 'dF=0', 'ffnunu', 'etauemu', 'muemutau', 'cu']}  # LFV, dF=0, dC=1 not in Bern
         self.assertSetEqual(fkeys_all - fkeys, set(), msg="Missing coefficients")
 
 class Testflavio2Bern(unittest.TestCase):
@@ -368,7 +368,7 @@ class Testflavio2Bern(unittest.TestCase):
 
     def test_nan(self):
         for k, v in self.to_wc.dict.items():
-            self.assertFalse(np.isnan(v), msg="{} is NaN".format(k))
+            self.assertFalse(np.isnan(v), msg=f"{k} is NaN")
 
     def count_nonzero(self):
         self.assertEqual(len(self.to_wc.dict), len(self.to_wc.dict))
@@ -378,7 +378,7 @@ class Testflavio2Bern(unittest.TestCase):
         for k, v in round_wc.dict.items():
             self.assertAlmostEqual(v, self.from_wc.dict[k],
                                    delta=1e-12,
-                                   msg="Failed for {} {}".format(k, v))
+                                   msg=f"Failed for {k} {v}")
 
     def test_jms(self):
         jms_wc = get_random_wc('WET', 'JMS')
@@ -389,7 +389,7 @@ class Testflavio2Bern(unittest.TestCase):
                 if k[0] != '7':  # to avoid problem with flavio tensors missing
                     self.assertAlmostEqual(v, jms_indirect.dict[k],
                                            delta=1e-8,
-                                           msg="Failed for {}".format(k))
+                                           msg=f"Failed for {k}")
 
 
     def test_incomplete_input(self):
@@ -415,7 +415,7 @@ class TestBern2flavioWET3(unittest.TestCase):
 
     def test_nan(self):
         for k, v in self.to_wc.dict.items():
-            self.assertFalse(np.isnan(v), msg="{} is NaN".format(k))
+            self.assertFalse(np.isnan(v), msg=f"{k} is NaN")
 
     def count_nonzero(self):
         self.assertEqual(len(self.to_wc.dict), len(self.to_wc.dict))
@@ -426,7 +426,7 @@ class TestBern2flavioWET3(unittest.TestCase):
             if k[0] != '7':  # to avoid problem with flavio tensors missing
                 self.assertAlmostEqual(v, self.from_wc.dict[k],
                                        delta=1e-12,
-                                       msg="Failed for {}".format(k))
+                                       msg=f"Failed for {k}")
 
     def test_jms(self):
         jms_wc = get_random_wc('WET-3', 'JMS')
@@ -436,7 +436,7 @@ class TestBern2flavioWET3(unittest.TestCase):
             if k in jms_indirect.dict:
                 self.assertAlmostEqual(v, jms_indirect.dict[k],
                                        delta=1e-4,
-                                       msg="Failed for {}".format(k))
+                                       msg=f"Failed for {k}")
 
     def test_incomplete_input(self):
         # generate and input WC instance with just 1 non-zero coeff.
@@ -451,9 +451,9 @@ class TestBern2flavioWET3(unittest.TestCase):
 
     def test_missing(self):
         fkeys = set(self.to_wc.values.keys())
-        fkeys_all = set([k for sname, s in wcxf.Basis['WET-3', 'flavio'].sectors.items()
+        fkeys_all = {k for sname, s in wcxf.Basis['WET-3', 'flavio'].sectors.items()
                          for k in s
-                         if sname not in ['mue', 'nunumue', 'dF=0', 'ffnunu']])  # LFV, dF=0 not in Bern
+                         if sname not in ['mue', 'nunumue', 'dF=0', 'ffnunu']}  # LFV, dF=0 not in Bern
         self.assertSetEqual(fkeys_all - fkeys, set(), msg="Missing coefficients")
 
 class Testflavio2BernWET3(unittest.TestCase):
@@ -467,7 +467,7 @@ class Testflavio2BernWET3(unittest.TestCase):
 
     def test_nan(self):
         for k, v in self.to_wc.dict.items():
-            self.assertFalse(np.isnan(v), msg="{} is NaN".format(k))
+            self.assertFalse(np.isnan(v), msg=f"{k} is NaN")
 
     def count_nonzero(self):
         self.assertEqual(len(self.to_wc.dict), len(self.to_wc.dict))
@@ -477,7 +477,7 @@ class Testflavio2BernWET3(unittest.TestCase):
         for k, v in round_wc.dict.items():
             self.assertAlmostEqual(v, self.from_wc.dict[k],
                                    delta=1e-12,
-                                   msg="Failed for {} {}".format(k, v))
+                                   msg=f"Failed for {k} {v}")
 
     def test_jms(self):
         jms_wc = get_random_wc('WET-3', 'JMS')
@@ -488,7 +488,7 @@ class Testflavio2BernWET3(unittest.TestCase):
                 if k[0] != '7':  # to avoid problem with flavio tensors missing
                     self.assertAlmostEqual(v, jms_indirect.dict[k],
                                            delta=1e-8,
-                                           msg="Failed for {}".format(k))
+                                           msg=f"Failed for {k}")
 
 
     def test_incomplete_input(self):
@@ -517,4 +517,4 @@ class TestFlavorKit2flavio(unittest.TestCase):
         to_wc_2 = self.from_wc.translate('JMS').translate('flavio')
         for k, v in self.to_wc.dict.items():
             self.assertEqual(v, to_wc_2.dict[k],
-                             msg="Failed for {}".format(k))
+                             msg=f"Failed for {k}")

--- a/wilson/translate/wet.py
+++ b/wilson/translate/wet.py
@@ -27,7 +27,7 @@ llflav = {'e': 0, 'm': 1, 't': 2}
 ## Class I (DeltaF = 2)##
 
 def _JMS_to_Bern_I(C, qq):
-    """From JMS to BernI basis (= traditional SUSY basis in this case)
+    r"""From JMS to BernI basis (= traditional SUSY basis in this case)
     for $\Delta F=2$ operators.
     `qq` should be 'sb', 'db', 'ds' or 'cu'"""
     if qq in ['sb', 'db', 'ds']:
@@ -37,26 +37,26 @@ def _JMS_to_Bern_I(C, qq):
         dd = 'uu'
         ij = tuple(uflav[q] for q in qq)
     else:
-        raise ValueError("not in Bern_I: ".format(qq))
+        raise ValueError(f"not in Bern_I: ")
     ji = (ij[1], ij[0])
     d = {
-        '1' + 2 * qq : C["V{}LL".format(dd)][ij + ij],
-        '2' + 2 * qq : C["S1{}RR".format(dd)][ji + ji].conj()
-                       - C["S8{}RR".format(dd)][ji + ji].conj() / (2 * Nc),
-        '3' + 2 * qq : C["S8{}RR".format(dd)][ji + ji].conj() / 2,
-        '4' + 2 * qq : -C["V8{}LR".format(dd)][ij + ij],
-        '5' + 2 * qq : -2 * C["V1{}LR".format(dd)][ij + ij]
-                       + C["V8{}LR".format(dd)][ij + ij] / Nc,
-        '1p' + 2 * qq : C["V{}RR".format(dd)][ij + ij],
-        '2p' + 2 * qq : C["S1{}RR".format(dd)][ij + ij]
-                       - C["S8{}RR".format(dd)][ij + ij] / (2 * Nc),
-        '3p' + 2 * qq : C["S8{}RR".format(dd)][ij + ij] / 2
+        '1' + 2 * qq : C[f"V{dd}LL"][ij + ij],
+        '2' + 2 * qq : C[f"S1{dd}RR"][ji + ji].conj()
+                       - C[f"S8{dd}RR"][ji + ji].conj() / (2 * Nc),
+        '3' + 2 * qq : C[f"S8{dd}RR"][ji + ji].conj() / 2,
+        '4' + 2 * qq : -C[f"V8{dd}LR"][ij + ij],
+        '5' + 2 * qq : -2 * C[f"V1{dd}LR"][ij + ij]
+                       + C[f"V8{dd}LR"][ij + ij] / Nc,
+        '1p' + 2 * qq : C[f"V{dd}RR"][ij + ij],
+        '2p' + 2 * qq : C[f"S1{dd}RR"][ij + ij]
+                       - C[f"S8{dd}RR"][ij + ij] / (2 * Nc),
+        '3p' + 2 * qq : C[f"S8{dd}RR"][ij + ij] / 2
             }
     return d
 
 
 def _Bern_to_JMS_I(C, qq):
-    """From Bern to JMS basis for $\Delta F=2$ operators.
+    r"""From Bern to JMS basis for $\Delta F=2$ operators.
     `qq` should be 'sb', 'db', 'ds' or 'cu'"""
     if qq in ['sb', 'db', 'ds']:
         dd = 'dd'
@@ -65,16 +65,16 @@ def _Bern_to_JMS_I(C, qq):
         dd = 'uu'
         ij = '{}{}'.format(uflav[qq[0]] + 1, uflav[qq[1]] + 1)
     else:
-        raise ValueError("not in Bern_I: ".format(qq))
+        raise ValueError(f"not in Bern_I: ")
     ji = ij[1] + ij[0]
-    d = {"V{}LL_{}{}".format(dd, ij, ij): C['1' + 2 * qq],
-         "S1{}RR_{}{}".format(dd, ji, ji): C['2' + 2 * qq].conjugate() + C['3' + 2 * qq].conjugate() / 3,
-         "S8{}RR_{}{}".format(dd, ji, ji): 2 * C['3' + 2 * qq].conjugate(),
-         "V1{}LR_{}{}".format(dd, ij, ij): -C['4' + 2 * qq] / 6 - C['5' + 2 * qq] / 2,
-         "V8{}LR_{}{}".format(dd, ij, ij): -C['4' + 2 * qq],
-         "V{}RR_{}{}".format(dd, ij, ij): C['1p' + 2 * qq],
-         "S1{}RR_{}{}".format(dd, ij, ij): C['2p' + 2 * qq] + C['3p' + 2 * qq] / 3,
-         "S8{}RR_{}{}".format(dd, ij, ij): 2 * C['3p' + 2 * qq],
+    d = {f"V{dd}LL_{ij}{ij}": C['1' + 2 * qq],
+         f"S1{dd}RR_{ji}{ji}": C['2' + 2 * qq].conjugate() + C['3' + 2 * qq].conjugate() / 3,
+         f"S8{dd}RR_{ji}{ji}": 2 * C['3' + 2 * qq].conjugate(),
+         f"V1{dd}LR_{ij}{ij}": -C['4' + 2 * qq] / 6 - C['5' + 2 * qq] / 2,
+         f"V8{dd}LR_{ij}{ij}": -C['4' + 2 * qq],
+         f"V{dd}RR_{ij}{ij}": C['1p' + 2 * qq],
+         f"S1{dd}RR_{ij}{ij}": C['2p' + 2 * qq] + C['3p' + 2 * qq] / 3,
+         f"S8{dd}RR_{ij}{ij}": 2 * C['3p' + 2 * qq],
          }
     if qq == 'cu':
         # here we need to convert some operators that are not in the basis
@@ -83,7 +83,7 @@ def _Bern_to_JMS_I(C, qq):
     return d
 
 def _JMS_to_EOS_I(C, qq, p):
-    """
+    r"""
     From JMS to EOS basis (= traditional SUSY basis in this case) for $\Delta F=2$ operators.
     `qq` should be one of 'sb', 'db'.
     """
@@ -91,27 +91,27 @@ def _JMS_to_EOS_I(C, qq, p):
         dd = 'dd'
         ij = tuple(dflav[q] for q in qq)
     else:
-        raise ValueError("not in EOS_I: ".format(qq))
+        raise ValueError(f"not in EOS_I: ")
     ji = (ij[1], ij[0])
     V = ckmutil.ckm.ckm_tree(p["Vus"], p["Vub"], p["Vcb"], p["delta"])
     prefactor = sqrt(2) / p['GF'] / 4 / (V[2, ij[1]] * V[2, ij[0]].conj())**2
     d = {
-        2 * qq + '::c1'   : prefactor * C["V{}LL".format(dd)][ij + ij],
-        2 * qq + '::c2'   : prefactor * (C["S1{}RR".format(dd)][ji + ji].conj()
-                          - C["S8{}RR".format(dd)][ji + ji].conj() / (2 * Nc)),
-        2 * qq + '::c3'   : prefactor * C["S8{}RR".format(dd)][ji + ji].conj() / 2,
-        2 * qq + '::c4'   : prefactor * -C["V8{}LR".format(dd)][ij + ij],
-        2 * qq + '::c5'   : prefactor * (-2 * C["V1{}LR".format(dd)][ij + ij]
-                          + C["V8{}LR".format(dd)][ij + ij] / Nc),
-        2 * qq + '::c1\'' : prefactor * C["V{}RR".format(dd)][ij + ij],
-        2 * qq + '::c2\'' : prefactor * (C["S1{}RR".format(dd)][ij + ij]
-                          - C["S8{}RR".format(dd)][ij + ij] / (2 * Nc)),
-        2 * qq + '::c3\'' : prefactor * C["S8{}RR".format(dd)][ij + ij] / 2
+        2 * qq + '::c1'   : prefactor * C[f"V{dd}LL"][ij + ij],
+        2 * qq + '::c2'   : prefactor * (C[f"S1{dd}RR"][ji + ji].conj()
+                          - C[f"S8{dd}RR"][ji + ji].conj() / (2 * Nc)),
+        2 * qq + '::c3'   : prefactor * C[f"S8{dd}RR"][ji + ji].conj() / 2,
+        2 * qq + '::c4'   : prefactor * -C[f"V8{dd}LR"][ij + ij],
+        2 * qq + '::c5'   : prefactor * (-2 * C[f"V1{dd}LR"][ij + ij]
+                          + C[f"V8{dd}LR"][ij + ij] / Nc),
+        2 * qq + '::c1\'' : prefactor * C[f"V{dd}RR"][ij + ij],
+        2 * qq + '::c2\'' : prefactor * (C[f"S1{dd}RR"][ij + ij]
+                          - C[f"S8{dd}RR"][ij + ij] / (2 * Nc)),
+        2 * qq + '::c3\'' : prefactor * C[f"S8{dd}RR"][ij + ij] / 2
     }
     return d
 
 def _BernI_to_Flavio_I(C, qq):
-    """From BernI to FlavioI basis for $\Delta F=2$ operators.
+    r"""From BernI to FlavioI basis for $\Delta F=2$ operators.
     `qq` should be 'sb', 'db', 'ds' or 'uc'"""
     qqf = qq[::-1]  # flavio uses "bs" instead of "sb" etc.
     if qq in ['sb', 'db', 'ds', 'cu']:
@@ -126,11 +126,11 @@ def _BernI_to_Flavio_I(C, qq):
             'CSLR_' + 2*qqf: C["4" + 2*qq]
             }
     else:
-        raise ValueError("not in Flavio_I: ".format(qq))
+        raise ValueError(f"not in Flavio_I: ")
 
 
 def _FlavioI_to_Bern_I(C, qq):
-    """From FlavioI to BernI basis for $\Delta F=2$ operators.
+    r"""From FlavioI to BernI basis for $\Delta F=2$ operators.
     `qq` should be 'sb', 'db', 'ds' or 'uc'"""
     qqb = qq[::-1]  # flavio uses "bs" instead of "sb" etc.
     if qq in ['bs', 'bd', 'sd', 'uc']:
@@ -145,11 +145,11 @@ def _FlavioI_to_Bern_I(C, qq):
             '3p' + 2*qqb: -8 * C["CTRR_" + 2*qq],
             }
     else:
-        raise ValueError("not in Bern_I: ".format(qq))
+        raise ValueError(f"not in Bern_I: ")
 
 
 def _BernI_to_FormFlavor_I(C, qq):
-    """From BernI to FormFlavorI basis for $\Delta F=2$ operators.
+    r"""From BernI to FormFlavorI basis for $\Delta F=2$ operators.
     `qq` should be 'sb', 'db', 'ds' or 'uc'"""
     qqf = qq[::-1] # FormFlavour uses "bs" instead of "sb" etc.
     if qq in ['sb', 'db', 'ds']:
@@ -175,7 +175,7 @@ def _BernI_to_FormFlavor_I(C, qq):
             'CSLR_' + 2*qq: C["4" + 2*qq].conjugate()
             }
     else:
-        raise ValueError("{} not in FormFlavor_I".format(qq))
+        raise ValueError(f"{qq} not in FormFlavor_I")
 
 
 ## Class II ##
@@ -437,7 +437,7 @@ def _Fierz_to_JMS_III_IV_V(Fqqqq, qqqq):
         'S8uuRR_' + f4 + f1 + f2 + f3: -16 * F['F' + qqqq + '9p'].conjugate()
         }
         return symmetrize_JMS_dict(d)
-    raise ValueError("Case not implemented: {}".format(qqqq))
+    raise ValueError(f"Case not implemented: {qqqq}")
 
 def _JMS_to_Fierz_III_IV_V(C, qqqq):
     """From JMS to 4-quark Fierz basis for Classes III, IV and V.
@@ -621,7 +621,7 @@ def _JMS_to_Fierz_III_IV_V(C, qqqq):
                                     C["S8uuRR"][f4, f1, f2, f3].conj() / 16 / Nc
                                     }
     else:
-        raise ValueError("Case not implemented: {}".format(qqqq))
+        raise ValueError(f"Case not implemented: {qqqq}")
 
 
 def _Fierz_to_Bern_III_IV_V(Fqqqq, qqqq):
@@ -736,7 +736,7 @@ def _Fierz_to_Bern_III_IV_V(Fqqqq, qqqq):
         '10p'+qqqq : Fqqqq['F' + qqqq + '6p'] / 24
                      - Fqqqq['F' + qqqq + '8p'] / 24
                     }
-    raise ValueError("Case not implemented: {}".format(qqqq))
+    raise ValueError(f"Case not implemented: {qqqq}")
 
 def _Bern_to_Fierz_III_IV_V(C, qqqq):
     """From Bern to 4-quark Fierz basis for Classes III, IV and V.
@@ -794,7 +794,7 @@ def _Bern_to_Fierz_III_IV_V(C, qqqq):
                 'F' + qqqq + '9': (8 * C['10' + qqqq]) / 3 + C['7' + qqqq] - C['8' + qqqq] / 6 - 16 * C['9' + qqqq],
                 'F' + qqqq + '9p': (8 * C['10p' + qqqq]) / 3 + C['7p' + qqqq] - C['8p' + qqqq] / 6 - 16 * C['9p' + qqqq],
                 }
-    raise ValueError("Case not implemented: {}".format(qqqq))
+    raise ValueError(f"Case not implemented: {qqqq}")
 
 def _Fierz_to_EOS_III(Fqqqq, qqqq, p):
     """
@@ -869,7 +869,7 @@ def _Fierz_to_EOS_III(Fqqqq, qqqq, p):
                              - Fqqqq['F' + qqqq + '8p'] / 24
         }
         return {k: v * pf_ckm for k, v in d.items()}
-    raise ValueError("Case not implemented: {}".format(qqqq))
+    raise ValueError(f"Case not implemented: {qqqq}")
 
 def _Fierz_to_Flavio_V(Fqqqq, qqqq, parameters):
     p = parameters
@@ -923,7 +923,7 @@ def _Fierz_to_Flavio_V(Fqqqq, qqqq, parameters):
             'CTLLt_' + qqqq_fl: pf * Fqqqq['F' + qqqq + '10p'],
         }
     else:
-        raise ValueError("Sector not implemented: {}".format(qqqq))
+        raise ValueError(f"Sector not implemented: {qqqq}")
 
 
 def _Flavio_to_Fierz_V(Cqqqq, qqqq, parameters):
@@ -978,7 +978,7 @@ def _Flavio_to_Fierz_V(Cqqqq, qqqq, parameters):
             'F' + qqqq + '10p': pf * Cqqqq['CTLLt_' + qqqq_fl],
         }
     else:
-        raise ValueError("Sector not implemented: {}".format(qqqq))
+        raise ValueError(f"Sector not implemented: {qqqq}")
 
 
 def _Fierz_to_EOS_V(Fsbuu,Fsbdd,Fsbcc,Fsbss,Fsbbb,parameters):
@@ -1462,18 +1462,18 @@ def Fierz_to_JMS_chrom(C, qq):
     if qq[0] in dflav:
         s = dflav[qq[0]] + 1
         b = dflav[qq[1]] + 1
-        return {'dgamma_{}{}'.format(s, b): C['F7gamma' + qq],
-                'dG_{}{}'.format(s, b): C['F8g' + qq],
-                'dgamma_{}{}'.format(b, s): C['F7pgamma' + qq].conjugate(),
-                'dG_{}{}'.format(b, s): C['F8pg' + qq].conjugate(),
+        return {f'dgamma_{s}{b}': C['F7gamma' + qq],
+                f'dG_{s}{b}': C['F8g' + qq],
+                f'dgamma_{b}{s}': C['F7pgamma' + qq].conjugate(),
+                f'dG_{b}{s}': C['F8pg' + qq].conjugate(),
                 }
     else:
         u = uflav[qq[0]] + 1
         c = uflav[qq[1]] + 1
-        return {'ugamma_{}{}'.format(u, c): C['F7gamma' + qq],
-                'uG_{}{}'.format(u, c): C['F8g' + qq],
-                'ugamma_{}{}'.format(c, u): C['F7pgamma' + qq].conjugate(),
-                'uG_{}{}'.format(c, u): C['F8pg' + qq].conjugate(),
+        return {f'ugamma_{u}{c}': C['F7gamma' + qq],
+                f'uG_{u}{c}': C['F8g' + qq],
+                f'ugamma_{c}{u}': C['F7pgamma' + qq].conjugate(),
+                f'uG_{c}{u}': C['F8pg' + qq].conjugate(),
                 }
 
 
@@ -1487,7 +1487,7 @@ def Fierz_to_Bern_chrom(C, dd, parameters):
     elif dd == 'ds':
         mq = parameters['m_s']
     else:
-        KeyError("Not sure what to do with quark mass for flavour {}".format(dd))
+        KeyError(f"Not sure what to do with quark mass for flavour {dd}")
     return {
         '7gamma' + dd : gs**2 / e / mq * C['F7gamma' + dd ],
         '8g' + dd : gs / mq * C['F8g' + dd ],
@@ -1506,7 +1506,7 @@ def Bern_to_Fierz_chrom(C, dd, parameters):
     elif dd == 'ds':
         mq = parameters['m_s']
     else:
-        KeyError("Not sure what to do with quark mass for flavour {}".format(dd))
+        KeyError(f"Not sure what to do with quark mass for flavour {dd}")
     return {
         'F7gamma' + dd : C['7gamma' + dd] / (gs**2 / e / mq),
         'F8g' + dd : C['8g' + dd] / (gs / mq),
@@ -1529,7 +1529,7 @@ def Fierz_to_Flavio_chrom(C, qq, parameters):
     elif qq == 'uc':
         xi = V[1, 2].conj() * V[0, 2]
     else:
-        raise ValueError("Unexpected flavours: {}".format(qq))
+        raise ValueError(f"Unexpected flavours: {qq}")
     qqfl = qq[::-1]
     e = sqrt(4 * pi * parameters['alpha_e'])
     gs = sqrt(4 * pi * parameters['alpha_s'])
@@ -1540,7 +1540,7 @@ def Fierz_to_Flavio_chrom(C, qq, parameters):
     elif qq == 'uc':
         mq = parameters['m_c']
     else:
-        KeyError("Not sure what to do with quark mass for flavour {}".format(qq))
+        KeyError(f"Not sure what to do with quark mass for flavour {qq}")
     dic = {
         "C7_" + qqfl : (16 * pi**2) / e / mq * C['F7gamma' + qq],
         "C8_" + qqfl : (16 * pi**2) / gs / mq * C['F8g' + qq],
@@ -1565,7 +1565,7 @@ def Flavio_to_Fierz_chrom(C, qq, parameters):
     elif qq == 'uc':
         xi = V[1, 2].conj() * V[0, 2]
     else:
-        raise ValueError("Unexpected flavours: {}".format(qq))
+        raise ValueError(f"Unexpected flavours: {qq}")
     qqfl = qq[::-1]
     e = sqrt(4 * pi * parameters['alpha_e'])
     gs = sqrt(4 * pi * parameters['alpha_s'])
@@ -1576,7 +1576,7 @@ def Flavio_to_Fierz_chrom(C, qq, parameters):
     elif qq == 'uc':
         mq = parameters['m_c']
     else:
-        KeyError("Not sure what to do with quark mass for flavour {}".format(qq))
+        KeyError(f"Not sure what to do with quark mass for flavour {qq}")
     dic = {
         'F7gamma' + qq: C["C7_" + qqfl] / ((16 * pi**2) / e / mq),
         'F8g' + qq: C["C8_" + qqfl] / ((16 * pi**2) / gs / mq),
@@ -2242,7 +2242,7 @@ def FlavorKit_to_JMS(C, scale, parameters=None, sectors=None):
                 m = p['m_tau']
             C_out['egamma_' + ind] = 1/2 * e * m * v
         else:
-            raise ValueError("Unexpected key: {}".format(k))
+            raise ValueError(f"Unexpected key: {k}")
     return C_out
 
 

--- a/wilson/util/qcd.py
+++ b/wilson/util/qcd.py
@@ -47,9 +47,9 @@ def alpha_s(scale, f, alphasMZ=0.1185, loop=3):
         crd.nfMmu.nf = 4
         return_value = crd.AlH2AlL(asmc, mc, crd.nfMmu, scale, loop)
     else:
-        raise ValueError("Invalid input: f={}, scale={}".format(f, scale))
+        raise ValueError(f"Invalid input: f={f}, scale={scale}")
     if return_value == 0:
-        raise ValueError("Return value is 0, probably `scale={}` is too small.".format(scale))
+        raise ValueError(f"Return value is 0, probably `scale={scale}` is too small.")
     else:
         return return_value
 
@@ -88,7 +88,7 @@ def m_b(mbmb, scale, f, alphasMZ=0.1185, loop=3):
         crd.nfMmu.nf = 6
         return crd.mL2mH(mbmb, alphas_mb, mbmb, crd.nfMmu, scale, loop)
     else:
-        raise ValueError("Invalid input: f={}, scale={}".format(f, scale))
+        raise ValueError(f"Invalid input: f={f}, scale={scale}")
 
 
 @lru_cache(32)
@@ -114,7 +114,7 @@ def m_c(mcmc, scale, f, alphasMZ=0.1185, loop=3):
         crd.nfMmu.nf = 5
         return crd.mL2mH(mcmc, alphas_mc, mcmc, crd.nfMmu, scale, loop)
     else:
-        raise ValueError("Invalid input: f={}, scale={}".format(f, scale))
+        raise ValueError(f"Invalid input: f={f}, scale={scale}")
 
 
 @lru_cache(32)
@@ -146,4 +146,4 @@ def m_s(ms2, scale, f, alphasMZ=0.1185, loop=3):
         alphas_mc = alpha_s(mc, 4, alphasMZ=alphasMZ, loop=loop)
         return crd.mL2mH(msmc, alphas_mc, mc, crd.nfMmu, scale, loop)
     else:
-        raise ValueError("Invalid input: f={}, scale={}".format(f, scale))
+        raise ValueError(f"Invalid input: f={f}, scale={scale}")

--- a/wilson/util/smeftutil.py
+++ b/wilson/util/smeftutil.py
@@ -799,11 +799,11 @@ for i in range(3):
         for k in range(3):
             for l in range(3):
                 # class 4: symmetric under interachange of currents
-                _d_4[i, j, k, l] = len(set([(i, j, k, l), (k, l, i, j)]))
+                _d_4[i, j, k, l] = len({(i, j, k, l), (k, l, i, j)})
                 # class 6: symmetric under interachange of currents + Fierz
-                _d_6[i, j, k, l] = len(set([(i, j, k, l), (k, l, i, j), (k, j, i, l), (i, l, k, j)]))
+                _d_6[i, j, k, l] = len({(i, j, k, l), (k, l, i, j), (k, j, i, l), (i, l, k, j)})
                 # class 7: symmetric under interachange of first two indices
-                _d_7[i, j, k, l] = len(set([(i, j, k, l), (j, i, k, l)]))
+                _d_7[i, j, k, l] = len({(i, j, k, l), (j, i, k, l)})
 
 
 _scale_dict = C_array2dict(np.ones(9999))

--- a/wilson/util/test_smeftutil.py
+++ b/wilson/util/test_smeftutil.py
@@ -19,7 +19,7 @@ class TestSymm(unittest.TestCase):
         # check no parameter or WC was forgotten in the C_symm_keys lists
         self.assertEqual(
           set(smeftutil.C_keys),
-          set([c for cs in smeftutil.C_symm_keys.values() for c in cs])
+          {c for cs in smeftutil.C_symm_keys.values() for c in cs}
         )
 
     def test_symmetrize_symmetric(self):
@@ -77,12 +77,12 @@ class TestSymm(unittest.TestCase):
         C = smeftutil.wcxf2arrays_symmetrized(wc.dict)
         d = smeftutil.arrays2wcxf_nonred(C)
         for k, v in wc.dict.items():
-            self.assertAlmostEqual(v, d[k], msg="Failed for {}".format(k))
+            self.assertAlmostEqual(v, d[k], msg=f"Failed for {k}")
 
     def test_wcxf2array_incomplete(self):
         wc = wcxf.WC('SMEFT', 'Warsaw', 160, {'G': 1e-10})
         C = smeftutil.wcxf2arrays_symmetrized(wc.dict)
         d = smeftutil.arrays2wcxf_nonred(C)
         for k, v in d.items():
-            self.assertEqual(v, wc[k], msg="Failed for {}".format(k))
+            self.assertEqual(v, wc[k], msg=f"Failed for {k}")
             self.assertIsInstance(v, Number)

--- a/wilson/wcxf/__init__.py
+++ b/wilson/wcxf/__init__.py
@@ -14,9 +14,9 @@ all_bases = glob.glob(os.path.join(_root, 'bases', '*.basis.json'))
 child_bases = glob.glob(os.path.join(_root, 'bases', 'child', '*.basis.json'))
 
 for eft in all_efts:
-    with open(eft, 'r') as f:
+    with open(eft) as f:
         EFT.load(f)
 
 for basis in all_bases + child_bases:
-    with open(basis, 'r') as f:
+    with open(basis) as f:
         Basis.load(f)

--- a/wilson/wcxf/classes.py
+++ b/wilson/wcxf/classes.py
@@ -83,7 +83,7 @@ def _testtex(s, delete=True):
     logf = os.path.join(tmpd, 'textest.log')
     res['log'] = ''
     try:
-        with open(logf, 'r') as f:
+        with open(logf) as f:
             logl = f.readlines()
     except FileNotFoundError:
         pass
@@ -117,7 +117,7 @@ class NamedInstanceMetaclass(type):
     def __delitem__(cls, item):
         return cls.del_instance(item)
 
-class NamedInstanceClass(object, metaclass=NamedInstanceMetaclass):
+class NamedInstanceClass(metaclass=NamedInstanceMetaclass):
     """Base class for classes that have named instances that can be accessed
     by their name.
 
@@ -155,7 +155,7 @@ class NamedInstanceClass(object, metaclass=NamedInstanceMetaclass):
         cls.instances = OrderedDict()
 
 
-class WCxf(object):
+class WCxf:
     """Base class for WCxf files (not meant to be used directly)."""
 
     @classmethod
@@ -190,7 +190,7 @@ class WCxf(object):
                              default_flow_style=default_flow_style,
                             **kwargs)
         else:
-            raise ValueError("Format {} unknown: use 'json' or 'yaml'.".format(fmt))
+            raise ValueError(f"Format {fmt} unknown: use 'json' or 'yaml'.")
 
 class EFT(WCxf, NamedInstanceClass):
     """Class representing EFT files."""
@@ -227,7 +227,7 @@ class Basis(WCxf, NamedInstanceClass):
                 self.sectors = Basis[self.eft, self.parent].sectors.copy()
                 self.sectors.update(sectors)
             except (AttributeError, KeyError):
-                raise ValueError("Parent basis {} not found".format(self.parent))
+                raise ValueError(f"Parent basis {self.parent} not found")
         else:
             self.sectors = sectors
         self._all_wcs = None
@@ -254,10 +254,10 @@ class Basis(WCxf, NamedInstanceClass):
         try:
             eft_instance = EFT[self.eft]
         except (AttributeError, KeyError):
-            raise ValueError("EFT {} not defined".format(self.eft))
+            raise ValueError(f"EFT {self.eft} not defined")
         unknown_sectors = set(self.sectors.keys()) - set(eft_instance.sectors.keys())
         if unknown_sectors:
-            raise ValueError("Unknown sectors: {}".format(unknown_sectors))
+            raise ValueError(f"Unknown sectors: {unknown_sectors}")
         all_keys = [k for s in self.sectors.values() for k, v in s.items()]
         if len(all_keys) != len(set(all_keys)):  # we have duplicate keys!
             cnt = Counter(all_keys)
@@ -278,10 +278,10 @@ class Basis(WCxf, NamedInstanceClass):
                              + "{}".format(res['log']))
 
     def __repr__(self):
-        return "wcxf.Basis('{}', '{}', {{...}})".format(self.eft, self.basis)
+        return f"wcxf.Basis('{self.eft}', '{self.basis}', {{...}})"
 
     def _repr_markdown_(self):
-        md = "# Basis `{}` (EFT `{}`)\n\n".format(self.basis, self.eft)
+        md = f"# Basis `{self.basis}` (EFT `{self.eft}`)\n\n"
         if hasattr(self, 'metadata') and 'description' in self.metadata:
             md += self.metadata['description'] + "\n\n"
         return md
@@ -295,7 +295,7 @@ class Basis(WCxf, NamedInstanceClass):
                r"\left( C_i \, O_i + C^*_i \, O^\dagger_i\right).$$")
         md += "\n\n"
         for s, wcs in self.sectors.items():
-            md += "### `{}`\n\n".format(s)
+            md += f"### `{s}`\n\n"
             if wcs:
                 md += "| WC name | Operator | Type |\n"
                 # NB: this is meant for pandoc; it computes column widths
@@ -370,11 +370,11 @@ class WC(WCxf):
         try:
             eft_instance = EFT[self.eft]
         except (AttributeError, KeyError):
-            raise ValueError("EFT {} not defined".format(self.eft))
+            raise ValueError(f"EFT {self.eft} not defined")
         try:
             basis_instance = Basis[self.eft, self.basis]
         except (AttributeError, KeyError):
-            raise ValueError("Basis {} not defined for EFT {}".format(self.basis, self.eft))
+            raise ValueError(f"Basis {self.basis} not defined for EFT {self.eft}")
         unknown_keys = set(self.values.keys()) - set(basis_instance.all_wcs)
         assert unknown_keys == set(), \
             "Wilson coefficients do not exist in this basis: " + str(unknown_keys)
@@ -409,9 +409,9 @@ class WC(WCxf):
 
     def _repr_markdown_(self):
         md = "## WCxf Wilson coefficients\n\n"
-        md += "**EFT:** `{}`\n\n".format(self.eft)
-        md += "**Basis:** `{}`\n\n".format(self.basis)
-        md += "**Scale:** {} GeV\n\n".format(self.scale)
+        md += f"**EFT:** `{self.eft}`\n\n"
+        md += f"**Basis:** `{self.basis}`\n\n"
+        md += f"**Scale:** {self.scale} GeV\n\n"
         md += "### Values\n\n"
         md += "| WC name | Value |\n"
         # NB: this is meant for pandoc; it computes column widths
@@ -419,7 +419,7 @@ class WC(WCxf):
         # fractions of line width (default: 72)
         md += "|" + 20 * "-" + "|" + 52 * "-" + "|\n"
         for name, v in self.dict.items():
-            md += "| `{}` | {} |\n".format(name, v)
+            md += f"| `{name}` | {v} |\n"
         return md
 
     def _repr_html_(self):
@@ -461,7 +461,7 @@ class WC(WCxf):
         try:
             translator = Translator[self.eft, self.basis, to_basis]
         except (KeyError, AttributeError):
-            raise ValueError("No translator from basis {} to {} found.".format(self.basis, to_basis))
+            raise ValueError(f"No translator from basis {self.basis} to {to_basis} found.")
         return translator.translate(self, parameters=parameters, sectors=sectors)
 
     def match(self, to_eft, to_basis, parameters=None):
@@ -472,7 +472,7 @@ class WC(WCxf):
         try:
             matcher = Matcher[self.eft, self.basis, to_eft, to_basis]
         except (KeyError, AttributeError):
-            raise ValueError("No matcher from EFT {} in basis {} to EFT {} in basis {} found.".format(self.eft, self.basis, to_eft, to_basis))
+            raise ValueError(f"No matcher from EFT {self.eft} in basis {self.basis} to EFT {to_eft} in basis {to_basis} found.")
         return matcher.match(self, parameters=parameters)
 
 

--- a/wilson/wcxf/cli.py
+++ b/wilson/wcxf/cli.py
@@ -137,7 +137,7 @@ def eos():
     elif args.output == sys.stdout and args.eoshome is not None:
         output_dir = os.path.join(args.eoshome, 'parameters')
         if not os.path.isdir(output_dir):
-            logging.error("Output directory {} does not exist".format(output_dir))
+            logging.error(f"Output directory {output_dir} does not exist")
             return 1
         f = open(os.path.join(output_dir, 'wcxf.yaml'), 'w')
     else:

--- a/wilson/wcxf/converters/dsixtools.py
+++ b/wilson/wcxf/converters/dsixtools.py
@@ -201,7 +201,7 @@ def wc_dict2lha(wc, skip_redundant=True, skip_zero=True):
     return {'BLOCK': d}
 
 
-class SMEFTio(object):
+class SMEFTio:
 
     def __init__(self):
         """Initialize the SMEFTio instance."""

--- a/wilson/wcxf/converters/dsixtools_definitions.py
+++ b/wilson/wcxf/converters/dsixtools_definitions.py
@@ -1,4 +1,3 @@
-
 # elements that are redundant and can thus be omitted in the input/output
 redundant_elements = {'G': [],
  'Gd': [],

--- a/wilson/wcxf/converters/eos.py
+++ b/wilson/wcxf/converters/eos.py
@@ -13,7 +13,7 @@ def get_sm_wcs(eos_parameter_dir):
     all_wcs = {}
     yamlfiles = glob.glob(os.path.join(eos_parameter_dir, '*.yaml'))
     for yamlfile in yamlfiles:
-        with open(yamlfile, 'r') as f:
+        with open(yamlfile) as f:
             wcs = yaml.safe_load(f)
         meta = wcs.get('@metadata@', {})
         if 'wcxf-relevant' in meta and meta['wcxf-relevant']:

--- a/wilson/wcxf/converters/test_dsixtools.py
+++ b/wilson/wcxf/converters/test_dsixtools.py
@@ -9,15 +9,15 @@ my_path = os.path.dirname(os.path.realpath(__file__))
 data_path = os.path.join(my_path, '..', 'data')
 
 
-with open(os.path.join(data_path, 'WCsInput-CPV-SMEFT.dat'), 'r') as f:
+with open(os.path.join(data_path, 'WCsInput-CPV-SMEFT.dat')) as f:
     wcin_lha = f.read()
-with open(os.path.join(data_path, 'Options.dat'), 'r') as f:
+with open(os.path.join(data_path, 'Options.dat')) as f:
     options = f.read()
-with open(os.path.join(data_path, 'SMInput-CPV.dat'), 'r') as f:
+with open(os.path.join(data_path, 'SMInput-CPV.dat')) as f:
     smin = f.read()
-with open(os.path.join(data_path, 'WCsInput-CPV-SMEFT.json'), 'r') as f:
+with open(os.path.join(data_path, 'WCsInput-CPV-SMEFT.json')) as f:
     wcin_json = f.read()
-with open(os.path.join(data_path, 'WCsInput-CPV-SMEFT.yaml'), 'r') as f:
+with open(os.path.join(data_path, 'WCsInput-CPV-SMEFT.yaml')) as f:
     wcin_yaml = f.read()
 
 
@@ -48,7 +48,7 @@ class TestDsixTools(unittest.TestCase):
         self.assertTrue(d2)
         self.assertEqual(set(d1.keys()), set(d2.keys()))
         for k in d1:
-            self.assertEqual(d1[k], d2[k], msg="Failed for {}".format(k))
+            self.assertEqual(d1[k], d2[k], msg=f"Failed for {k}")
 
     def test_cli_wcxf2dsixtools(self):
         smeftio = dsixtools.SMEFTio()

--- a/wilson/wcxf/converters/test_smeftsim.py
+++ b/wilson/wcxf/converters/test_smeftsim.py
@@ -25,7 +25,7 @@ class TestSMEFTsim(unittest.TestCase):
             outf = os.path.join(tmpdir, 'wcxf2smeftsim_param_card.dat')
             self.assertTrue(os.path.isfile, outf)
             # check if can be imported as LHA
-            with open(outf, 'r') as f:
+            with open(outf) as f:
                 card = pylha.load(f)
             # check dict is not empty
             self.assertTrue(card)
@@ -43,7 +43,7 @@ class TestSMEFTsim(unittest.TestCase):
         # check if file is present
         outf = os.path.join(tmpdir, 'wcxf2smeftsim_param_card.dat')
         self.assertTrue(os.path.isfile, outf)
-        with open(outf, 'r') as f:
+        with open(outf) as f:
             card = pylha.load(f)
         self.assertEqual(dict(card['BLOCK']['FRBlock']['values'])[691],
                          1e6 * 4e-6 / 2,  # symmetry factor of 1 / 2!

--- a/wilson/wcxf/test_bases.py
+++ b/wilson/wcxf/test_bases.py
@@ -7,4 +7,4 @@ class TestBases(unittest.TestCase):
             try:
                 basis.validate()
             except:
-                self.fail("Basis {}-{} failed to validate".format(basis.eft, basis.basis))
+                self.fail(f"Basis {basis.eft}-{basis.basis} failed to validate")

--- a/wilson/wcxf/test_cli.py
+++ b/wilson/wcxf/test_cli.py
@@ -41,7 +41,7 @@ class TestCLI(unittest.TestCase):
             f.write(yml1)
         _, fout = tempfile.mkstemp()
         res = subprocess.run(['wcxf', 'convert', 'json', fin, '--output', fout])
-        with open(fout, 'r') as f:
+        with open(fout) as f:
             d_json3 = json.load(f)
         self.assertDictEqual(d_yml1, d_json3)
         # delete temp files
@@ -52,7 +52,7 @@ class TestCLI(unittest.TestCase):
             f.write(json1)
         _, fout = tempfile.mkstemp()
         res = subprocess.run(['wcxf', 'convert', 'yaml', fin, '--output', fout])
-        with open(fout, 'r') as f:
+        with open(fout) as f:
             yml3 = f.read()
         d_yml3 = yaml.safe_load(yml3)
         self.assertDictEqual(d_yml3, d_json1)

--- a/wilson/wcxf/test_wet.py
+++ b/wilson/wcxf/test_wet.py
@@ -41,7 +41,7 @@ class TestWET(unittest.TestCase):
             L = sum([1 if isreal(k) else 2 for k in all_wc if s in k])
             try:
                 self.assertEqual(L, n,
-                             msg="Failed for {}".format(s))
+                             msg=f"Failed for {s}")
             except Exception as exc:
                 print(exc)
         # compare individual counts to tables 11-17 in arXiv:1709.04486


### PR DESCRIPTION
python 3.5 has reached its EOL, so let's explicitly require >= 3.6 and make use of its features