### PR TITLE
Fix deployment logic

### DIFF
--- a/.github/workflows/check+deploy.yaml
+++ b/.github/workflows/check+deploy.yaml
@@ -5,7 +5,7 @@ on:
     pull_request:
 
     release:
-        types: [created]
+        types: [ published ]
 
 name: Check & Deploy
 
@@ -21,7 +21,7 @@ jobs:
                 path: _src/
 
             - name: Verify release version matches source code version
-              if: github.event == 'release' && startsWith(github.ref, 'refs/tags/v')
+              if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
               shell: bash
               run: |
                 pushd _src
@@ -69,7 +69,7 @@ jobs:
                 path: dist
 
             - name: Upload to PyPI
-              if: github.event == 'release' && startsWith(github.ref, 'refs/tags/v')
+              if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
               uses: pypa/gh-action-pypi-publish@release/v1
               with:
                 user:     ${{ secrets.TWINE_USERNAME }}


### PR DESCRIPTION
 1. ``github.event`` is an object containing the event payload. We need
    to inspect ``github.event_name`` instead.

 2. A workflow will only be triggered by *publishing* a release.