### PR TITLE
fix _json_to_yaml and raise error if latex not found

### DIFF
--- a/.github/workflows/check+deploy.yaml
+++ b/.github/workflows/check+deploy.yaml
@@ -36,6 +36,9 @@ jobs:
                 python3 -m pip install .
                 popd
 
+            - name: Install LaTeX
+              run: sudo apt-get update && sudo apt-get install -y texlive-latex-base texlive-fonts-recommended
+
             - name: Run tests
               shell: bash
               run: |

--- a/wilson/wcxf/converters/yamljson.py
+++ b/wilson/wcxf/converters/yamljson.py
@@ -14,8 +14,7 @@ def convert_json(stream_in, stream_out):
 
 def convert_yaml(stream_in, stream_out):
     try:
-        return wcxf.classes._json_to_yaml(stream_in, stream_out,
-                                          default_flow_style=False)
+        return wcxf.classes._json_to_yaml(stream_in, stream_out, default_flow_style=False, sort_keys=False, width=9999)
     except json.decoder.JSONDecodeError:
         logging.error("Input file cannot be parsed as JSON.")
         return 1


### PR DESCRIPTION
This PR fixes two small issues in the `wcxf` module:
- The `_json_to_yaml` converter was changing the order of the list of operators in WCxf basis definitions and introduced additional line breaks. Both of these behaviors are now turned off.
- The `validate` method of the `Basis` class was only displaying a warning if LaTeX compilation was not possible due to a missing latex executable. Now an error is raised in this case and a `skip_tex` argument is added to the `validate` method to skip testing the LaTeX compilation.